### PR TITLE
Pin SimPEG version to merged commit

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,4 +18,4 @@ dependencies:
   - choclo
   - discretize
   - pip:
-    - git+https://github.com/simpeg/simpeg.git@gravity-choclo
+    - git+https://github.com/simpeg/simpeg.git@eb07ef133a6c5e1714ff1af181147cb172eba97c


### PR DESCRIPTION
Pin the SimPEG version in `environment.yml` to the commit in which the
new implementation of the gravity simulation was merged to `main`.

Fixes #4
